### PR TITLE
Fix missing label name in vignette

### DIFF
--- a/vignettes/fec_vignette.Rmd
+++ b/vignettes/fec_vignette.Rmd
@@ -220,7 +220,7 @@ ggplot(
   geom_point() +
   labs(
     title = "Not all Congressional Races are the same",
-    fill = "Candidate", x = "Total Votes", "Total Percent"
+    fill = "Candidate", x = "Total Votes", y = "Total Percent"
   ) +
   scale_y_continuous(labels = comma)
 ```


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We found that a label was unnamed, which caused problems. This PR fixes that problem.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
